### PR TITLE
fix: Todoモデルのリレーション修正とテスト環境でのVite無効化

### DIFF
--- a/app/Models/Todo.php
+++ b/app/Models/Todo.php
@@ -31,8 +31,13 @@ class Todo extends Model
         return $this->belongsTo(User::class, 'completed_by');
     }
 
-    public function registerd_by(): BelongsTo
+    public function registered_by(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'registerd_by');
+        return $this->belongsTo(User::class, 'registered_by', 'id');
+    }
+
+    public function getRegisteredByUserAttribute()
+    {
+        return $this->registered_by()->first();
     }
 }

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -12,7 +12,9 @@
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @if (!app()->environment('testing'))
+            @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @endif
     </head>
     <body class="font-sans text-gray-900 antialiased">
         <div class="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100 dark:bg-gray-900">

--- a/resources/views/todos/index.blade.php
+++ b/resources/views/todos/index.blade.php
@@ -53,7 +53,9 @@
         </div>
     </section>
 
-    @vite(['resources/js/todo/index.js'])
+    @if (!app()->environment('testing'))
+        @vite(['resources/js/todo/index.js'])
+    @endif
 
 </x-app-layout>
 

--- a/tests/Browser/TodoTest.php
+++ b/tests/Browser/TodoTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Browser;
+
+use App\Models\User;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class TodoTest extends DuskTestCase
+{
+    use DatabaseMigrations;
+
+    private User $user;
+    private Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // テストユーザーとカテゴリーを作成
+        $this->user = User::factory()->create([
+            'email' => 'test@example.com',
+            'password' => bcrypt('password'),
+            'role' => 'user'
+        ]);
+        $this->category = Category::factory()->create(['name' => 'テストカテゴリー']);
+    }
+
+    public function test_ログインしてTodoを作成して完了までの流れ(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/login')
+                   ->type('email', 'test@example.com')
+                   ->type('password', 'password')
+                   ->press('ログイン')
+                   ->assertPathIs('/')
+                   ->clickLink('新規作成')
+                   ->assertPathIs('/create')
+                   ->type('content', 'テストタスク')
+                   ->select('category_id', $this->category->id)
+                   ->radio('sharing_range', 'share')
+                   ->press('作成')
+                   ->assertPathIs('/')
+                   ->assertSee('テストタスク')
+                   ->press('完了')
+                   ->assertDontSee('テストタスク');
+        });
+    }
+
+    public function test_Todoの作成時のバリデーション(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/login')
+                   ->type('email', 'test@example.com')
+                   ->type('password', 'password')
+                   ->press('ログイン')
+                   ->clickLink('新規作成')
+                   ->press('作成')
+                   ->assertSee('タスクを入力してください')
+                   ->assertSee('カテゴリーを選択してください')
+                   ->assertSee('共有範囲を選択してください');
+        });
+    }
+
+    public function test_個人タスクの作成と表示(): void
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/login')
+                   ->type('email', 'test@example.com')
+                   ->type('password', 'password')
+                   ->press('ログイン')
+                   ->clickLink('新規作成')
+                   ->type('content', '個人タスク')
+                   ->select('category_id', $this->category->id)
+                   ->radio('sharing_range', 'personal')
+                   ->press('作成')
+                   ->clickLink('個人タスク一覧')
+                   ->assertSee('個人タスク');
+        });
+    }
+} 

--- a/tests/Feature/TodoFeatureTest.php
+++ b/tests/Feature/TodoFeatureTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Todo;
+use App\Models\User;
+use App\Models\Category;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class TodoFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private Category $category;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        // テストユーザーとカテゴリーを作成
+        $this->user = User::factory()->create(['role' => 'user']);
+        $this->category = Category::factory()->create(['name' => 'テストカテゴリー']);
+    }
+
+    public function test_認証済みユーザーがTodo一覧を表示できる(): void
+    {
+        $response = $this->actingAs($this->user)->get(route('todos.index'));
+        $response->assertStatus(200);
+    }
+
+    public function test_未認証ユーザーはTodo一覧にアクセスできない(): void
+    {
+        $response = $this->get(route('todos.index'));
+        $response->assertRedirect('/login');
+    }
+
+    public function test_認証済みユーザーが新規Todoを作成できる(): void
+    {
+        $todoData = [
+            'content' => 'テストタスク',
+            'category_id' => $this->category->id,
+            'sharing_range' => 'share',
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->post(route('todos.store'), $todoData);
+
+        $response->assertRedirect(route('todos.index'));
+        $this->assertDatabaseHas('todos', [
+            'content' => 'テストタスク',
+            'registered_by' => $this->user->id,
+        ]);
+    }
+
+    public function test_認証済みユーザーがTodoを完了できる(): void
+    {
+        $todo = Todo::create([
+            'content' => 'テストタスク',
+            'category_id' => $this->category->id,
+            'sharing_range' => 'share',
+            'registered_by' => $this->user->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->put(route('todos.complete', ['todoId' => $todo->id]));
+
+        $response->assertRedirect(route('todos.index'));
+        $this->assertDatabaseHas('todos', [
+            'id' => $todo->id,
+            'completed' => 1,
+            'completed_by' => $this->user->id,
+        ]);
+    }
+
+    public function test_認証済みユーザーがTodoを削除できる(): void
+    {
+        $todo = Todo::create([
+            'content' => 'テストタスク',
+            'category_id' => $this->category->id,
+            'sharing_range' => 'share',
+            'registered_by' => $this->user->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('todos.destroy', ['todoId' => $todo->id]));
+
+        $response->assertRedirect(route('todos.index'));
+        $this->assertDatabaseMissing('todos', ['id' => $todo->id]);
+    }
+
+    public function test_バリデーションエラーの場合は作成できない(): void
+    {
+        $todoData = [
+            'content' => str_repeat('a', 101), // 100文字制限を超える
+            'category_id' => $this->category->id,
+            'sharing_range' => 'share',
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->post(route('todos.store'), $todoData);
+
+        $response->assertSessionHasErrors(['content']);
+    }
+} 

--- a/tests/Unit/TodoTest.php
+++ b/tests/Unit/TodoTest.php
@@ -86,7 +86,9 @@ class TodoTest extends TestCase
             'registered_by' => $this->user->id,
         ]);
 
+        $todo = Todo::with(['category', 'registered_by'])->find($todo->id);
+
         $this->assertInstanceOf(Category::class, $todo->category);
-        $this->assertInstanceOf(User::class, $todo->registerd_by);
+        $this->assertInstanceOf(User::class, $todo->registered_by_user);
     }
 }


### PR DESCRIPTION
## 変更内容

### Todoモデルのリレーション修正
- `registered_by`メソッドのスペルミスを修正
- `registered_by_user`アクセサを追加してリレーションの取得を改善
- テストコードを更新してリレーションの検証を正しく行うように修正

### テスト環境の改善
- テスト環境でViteを無効化し、アセットコンパイルに関するエラーを解消

## テスト結果
全てのテストが正常に通過することを確認済み：
- 単体テスト
- 統合テスト
- E2Eテスト

## レビューのポイント
- リレーションの命名と実装の妥当性
- テスト環境の設定変更の影響